### PR TITLE
Manage multi-lined values

### DIFF
--- a/src/environment/environment.go
+++ b/src/environment/environment.go
@@ -1,0 +1,82 @@
+package environment
+
+import (
+	"strconv"
+	"unicode/utf8"
+)
+
+const lowerhex = "0123456789abcdef"
+
+// OneLine returns a Go string literal representing s.  The
+// returned string uses Go escape sequences (\t, \n, \xFF, \u0100) for
+// control characters and non-printable characters as defined by
+// strconv.IsPrint.
+func OneLine(s string, ASCIIonly bool) string {
+	var runeTmp [utf8.UTFMax]byte
+	buf := make([]byte, 0, 3*len(s)/2) // Try to avoid more allocations.
+	for width := 0; len(s) > 0; s = s[width:] {
+		r := rune(s[0])
+		width = 1
+		if r >= utf8.RuneSelf {
+			r, width = utf8.DecodeRuneInString(s)
+		}
+		if width == 1 && r == utf8.RuneError {
+			buf = append(buf, `\x`...)
+			buf = append(buf, lowerhex[s[0]>>4])
+			buf = append(buf, lowerhex[s[0]&0xF])
+			continue
+		}
+		if r == '\\' { // always backslashed
+			buf = append(buf, '\\')
+			buf = append(buf, byte(r))
+			continue
+		}
+		if ASCIIonly {
+			if r < utf8.RuneSelf && strconv.IsPrint(r) {
+				buf = append(buf, byte(r))
+				continue
+			}
+		} else if strconv.IsPrint(r) {
+			n := utf8.EncodeRune(runeTmp[:], r)
+			buf = append(buf, runeTmp[:n]...)
+			continue
+		}
+		switch r {
+		case '\a':
+			buf = append(buf, `\a`...)
+		case '\b':
+			buf = append(buf, `\b`...)
+		case '\f':
+			buf = append(buf, `\f`...)
+		case '\n':
+			buf = append(buf, `\n`...)
+		case '\r':
+			buf = append(buf, `\r`...)
+		case '\t':
+			buf = append(buf, `\t`...)
+		case '\v':
+			buf = append(buf, `\v`...)
+		default:
+			switch {
+			case r < ' ':
+				buf = append(buf, `\x`...)
+				buf = append(buf, lowerhex[s[0]>>4])
+				buf = append(buf, lowerhex[s[0]&0xF])
+			case r > utf8.MaxRune:
+				r = 0xFFFD
+				fallthrough
+			case r < 0x10000:
+				buf = append(buf, `\u`...)
+				for s := 12; s >= 0; s -= 4 {
+					buf = append(buf, lowerhex[r>>uint(s)&0xF])
+				}
+			default:
+				buf = append(buf, `\U`...)
+				for s := 28; s >= 0; s -= 4 {
+					buf = append(buf, lowerhex[r>>uint(s)&0xF])
+				}
+			}
+		}
+	}
+	return string(buf)
+}


### PR DESCRIPTION
Fix #3

for example.

```
$ etcdctl get /conf/key
line1
line2
\with backslash
```

Before:

```
$ cat /conf
key=line1
line2
\with backslash
```

Which will fail.
After:
with `-escapeBackslash=true`:

```
$ cat /conf
key=line1\\nline2\\n\\with backslash
```

with `-escapeBackslash=false`:

```
key=line1\nline2\n\with backslash
```
